### PR TITLE
typing gulpLoadPlugins as any

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -2,7 +2,7 @@ import * as gulp from 'gulp'
 import * as gulpLoadPlugins from 'gulp-load-plugins'
 import * as runSequence from 'run-sequence'
 
-const $ = gulpLoadPlugins()
+const $: any = gulpLoadPlugins()
 
 gulp.task('chromeManifest', ['js'], () => {
   return gulp


### PR DESCRIPTION
fix errors described below.

```
TSError: ⨯ Unable to compile TypeScript
gulpfile.ts (11,9): Property 'chromeManifest' does not exist on type '{}'. (2339)
gulpfile.ts (29,39): Property 'size' does not exist on type '{}'. (2339)
gulpfile.ts (42,13): Property 'zip' does not exist on type '{}'. (2339)
```